### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,6 +1,7 @@
 {
     "perl" : "6.*",
     "name" : "Crypt::Bcrypt",
+    "license" : "ISC",
     "version" : "1.3.2",
     "authors" : [ "github:carbin", "github:skinkade" ],
     "description" : "Easy bcrypt password hashing",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license