### PR TITLE
Fix 'zef install .', remove Panda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
-language: perl6
+language: minimal
 
-perl6:
-    - 2016.01
+services:
+  - docker
 
-sudo: false
 install:
-    - rakudobrew build-panda
-    - panda installdeps .
-    - panda-build
-    - panda install .
+- docker pull jjmerelo/test-perl6
+
+script: docker run -t -v $(pwd):/test --entrypoint /bin/sh jjmerelo/test-perl6 -c "perl6 -v && apk add --update --no-cache make gcc libc-dev && zef install --deps-only . && zef build ."

--- a/Build.pm
+++ b/Build.pm
@@ -2,22 +2,24 @@ use v6;
 use LibraryMake;
 
 class Build {
-    method build($dist-path) {
-        if !$*DISTRO.is-win {
-            my Str $ext = "$dist-path/ext/crypt_blowfish-1.3";
-            my Str $res = "$dist-path/resources";
-            mkdir($res);
-            unlink("$ext/crypt_blowfish.so");
-            unlink("$ext/crypt_blowfish.o", "$ext/crypt_gensalt.o");
-            unlink("$ext/wrapper.o", "$ext/x86.o");
-            make($dist-path, "$res");
-        }
+    sub make(Str $folder, Str $destfolder, IO() :$libname!) {
+        my %vars = LibraryMake::get-vars($destfolder);
+        %vars<LIB_NAME> = ~ $*VM.platform-library-name($libname);
+        mkdir($destfolder);
+        LibraryMake::process-makefile($folder, %vars);
+        shell(%vars<MAKE>);
     }
 
-    method isa($what) {
-        return True if $what.^name eq 'Panda::Builder';
-        callsame;
+    method build($workdir) {
+        my $destdir = 'resources/libraries';
+        mkdir 'resources';
+        mkdir $destdir;
+        make($workdir, $destdir, :libname<bcrypt>);
+        True;
     }
+
 }
 
-# vim: ft=perl6
+sub MAIN(Str $working-directory = '.' ) {
+    Build.new.build($working-directory);
+}

--- a/META6.json
+++ b/META6.json
@@ -10,6 +10,6 @@
     "provides" : {
         "Crypt::Bcrypt" : "lib/Crypt/Bcrypt.pm6"
     },
-    "resources" : [ "crypt_blowfish.so" ],
+    "resources" : [ "libraries/crypt_blowfish" ],
     "source-url" : "git://github.com/skinkade/p6-Crypt-Bcrypt.git"
 }

--- a/Makefile.in
+++ b/Makefile.in
@@ -7,7 +7,7 @@ LDFLAGS = $(LDSHARED) -s
 DIR = ext/crypt_blowfish-1.3/
 
 STATIC_OBJ = \
-	%DESTDIR%/crypt_blowfish.so
+	%DESTDIR%/libcrypt_blowfish.so
 
 BUILD_OBJS = \
 	$(DIR)crypt_blowfish.o $(DIR)crypt_gensalt.o $(DIR)wrapper.o $(DIR)x86.o

--- a/lib/Crypt/Bcrypt.pm6
+++ b/lib/Crypt/Bcrypt.pm6
@@ -1,5 +1,7 @@
 use v6;
-use strict;
+
+unit module Crypt::Bcrypt;
+
 use NativeCall;
 use Crypt::Random;
 
@@ -22,7 +24,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 =end LICENSE
 
-constant BCRYPT = %?RESOURCES<crypt_blowfish.so>.Str;
+constant BCRYPT = %?RESOURCES<libraries/crypt_blowfish>;
 
 
 


### PR DESCRIPTION
I was unable to install your module using zef, and even after cloning, building the .so locally and running "zef install .", I could not get it to work.

Not sure if that's just me, is this working for you with a current ecosystem?

In case you are interested, the following changes allow me to install with zef.