### PR TITLE
Add module declaration

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -2,7 +2,7 @@
     "perl" : "6.*",
     "name" : "Crypt::Bcrypt",
     "license" : "ISC",
-    "version" : "1.3.2",
+    "version" : "1.3.3",
     "authors" : [ "github:carbin", "github:skinkade" ],
     "description" : "Easy bcrypt password hashing",
     "depends" : [ ],

--- a/lib/Crypt/Bcrypt.pm6
+++ b/lib/Crypt/Bcrypt.pm6
@@ -3,6 +3,8 @@ use strict;
 use NativeCall;
 use Crypt::Random;
 
+unit module Crypt::Bcrypt;
+
 =begin LICENSE
 
 Copyright (c) 2014-2015, carlin <cb@viennan.net>


### PR DESCRIPTION
This is so 'try require ::("Crypt::Bcrypt")' will return a value
that can be tested to determine whether the module is present.

This is so that I can try to use the module in Crypt::AnyPasswordHash
if it is installed.

Thanks.